### PR TITLE
Make mysql_bosh_lite sleep longer so it fails less

### DIFF
--- a/scripts/mysql_bosh_lite
+++ b/scripts/mysql_bosh_lite
@@ -46,7 +46,7 @@ kill_tree() {
 {
 	get_database_password &&
 	ssh_tunnel &&
-	sleep 3 &&
+	sleep 5 &&
 	connect_to_db &&
 	kill_tree $ssh_pid
 } || {


### PR DESCRIPTION
Authored-by: Greg Cobb <gcobb@pivotal.io>