### PR TITLE
Update the default set of ops files for deploy script

### DIFF
--- a/bin/create_and_deploy
+++ b/bin/create_and_deploy
@@ -11,8 +11,8 @@ echo "bosh deploy cf-deployment.yml -o..."
 
 bosh deploy "${cfd_dir}/cf-deployment.yml" \
   -v system_domain=$BOSH_LITE_DOMAIN \
-  -o "${capi_ci_dir}/cf-deployment-operations/skip-cert-verify.yml" \
   -o "${cfd_dir}/operations/bosh-lite.yml" \
   -o "${cfd_dir}/operations/use-compiled-releases.yml" \
   -o "${capi_ci_dir}/cf-deployment-operations/use-latest-capi.yml" \
+  -o "${capi_ci_dir}/cf-deployment-operations/seed-credhub-asg.yml" \
   $@


### PR DESCRIPTION
- Remove skip-cert-verify, because it is not included by default in cf-d (and the ops file no longer exists in the `capi-ci`)
- Add seed-credhub-asg, because it is included by default in the CAPI pool